### PR TITLE
Add PHP 8.4 support to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} (${{ matrix.dependency-version }})


### PR DESCRIPTION
## Summary
- Add PHP 8.4 to the CI test matrix to ensure compatibility with the latest PHP version

## Test plan
- [ ] Verify CI passes on all PHP versions (8.1, 8.2, 8.3, 8.4)
- [ ] Check that both prefer-lowest and prefer-stable dependency versions work

🤖 Generated with [Claude Code](https://claude.ai/code)