### PR TITLE
Fix PSR-7 __toString compliance and improve docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,12 +7,9 @@
 /.gitattributes              export-ignore
 /.gitignore                  export-ignore
 /CHANGELOG.md                export-ignore
-/UPGRADING-1.0.md            export-ignore
 /CONTRIBUTING.md             export-ignore
 /LICENSE                     export-ignore
 /phpcs.xml                   export-ignore
 /phpunit.xml                 export-ignore
 /phpstan.neon                export-ignore
 /tests                       export-ignore
-/examples                    export-ignore
-/docs                        export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased]
+### Added
+- Add usage examples to README
+- Add `.editorconfig`
+
+### Changed
+- Update codecov badge to point to the `1.x` branch
+- Remove dead `export-ignore` entries from `.gitattributes`
+
+### Fixed
+- `Stream::__toString()` no longer throws on non-readable/detached streams, conforming to PSR-7
 
 ## [1.1.0] - 2025-09-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](http://poser.pugx.org/digitalcz/streams/license)](https://packagist.org/packages/digitalcz/streams) 
 [![PHP Version Require](http://poser.pugx.org/digitalcz/streams/require/php)](https://packagist.org/packages/digitalcz/streams)
 [![CI](https://github.com/digitalcz/streams/workflows/CI/badge.svg)](https://github.com/digitalcz/streams/actions)
-[![codecov](https://codecov.io/gh/digitalcz/streams/branch/0.x/graph/badge.svg?token=QzZ5iMNkg3)](https://codecov.io/gh/digitalcz/streams)
+[![codecov](https://codecov.io/gh/digitalcz/streams/branch/1.x/graph/badge.svg?token=QzZ5iMNkg3)](https://codecov.io/gh/digitalcz/streams)
 
 Opinionated abstraction around PHP streams implementing PSR-7 StreamInterface.
 It aims to improve working with files or remote streams in unified way.
@@ -19,6 +19,94 @@ Via [Composer](https://getcomposer.org/)
 
 ```bash
 $ composer require digitalcz/streams
+```
+
+## Usage
+
+All streams implement `DigitalCz\Streams\StreamInterface`, which extends PSR-7
+`Psr\Http\Message\StreamInterface` and adds a few convenience methods
+(`copy()`, void-returning `close()`/`seek()`, …).
+
+### Stream
+
+A wrapper around any PHP stream resource. Use `Stream::from()` to build one from
+a string, a resource or another PSR-7 stream — the data is held in `php://temp`.
+
+```php
+use DigitalCz\Streams\Stream;
+
+// From a string
+$stream = Stream::from('Hello world');
+echo $stream->getContents();        // "Hello world"
+
+// From an existing resource
+$stream = Stream::from(fopen('php://memory', 'rb+'));
+
+// From another PSR-7 stream
+$stream = Stream::from($psrStream);
+
+// Wrapping a resource directly (optionally with a known size)
+$stream = new Stream(fopen('data.bin', 'rb'));
+
+// Copy another stream into this one (returns bytes written)
+$bytes = $stream->copy($otherStream);
+```
+
+### File
+
+A stream backed by a real file on disk. Adds `getPath()` and `delete()`.
+
+```php
+use DigitalCz\Streams\File;
+
+$file = new File('/path/to/file.txt');      // opened with mode "rb+" by default
+echo $file->getPath();
+
+// Build a file from a string / resource / PSR-7 stream.
+// A string that is an existing path opens that file, otherwise it is the content.
+$file = File::from('contents written to a temp file');
+
+$temp = File::temp();                        // empty file in the system temp dir
+$file->delete();                             // close and unlink
+```
+
+### TempFile
+
+Like `File`, but backed by `tmpfile()` — the underlying file is removed
+automatically once the stream handle is closed.
+
+```php
+use DigitalCz\Streams\TempFile;
+
+$temp = TempFile::from('temporary content');
+echo $temp->getPath();
+$temp->close();                              // file is deleted on close
+```
+
+### BufferedStream
+
+Wraps a non-seekable / one-shot source stream and buffers what it reads into
+`php://temp`, so the source can be re-read and seeked. It is read-only.
+
+```php
+use DigitalCz\Streams\BufferedStream;
+
+$buffered = new BufferedStream($nonSeekableSource);
+$head = $buffered->read(1024);
+$buffered->rewind();                         // works even if the source could not seek
+$all = $buffered->getContents();
+```
+
+### StreamWrapper
+
+Turns a `StreamInterface` back into a native PHP stream resource, usable with
+any function that expects one (`fread`, `fgets`, `stream_copy_to_stream`, …).
+
+```php
+use DigitalCz\Streams\StreamWrapper;
+
+$resource = StreamWrapper::from($stream);
+$line = fgets($resource);
 ```
 
 ## Change log

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -6,6 +6,7 @@ namespace DigitalCz\Streams;
 
 use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface as PsrStreamInterface;
+use Throwable;
 
 final class Stream implements StreamInterface
 {
@@ -303,11 +304,16 @@ final class Stream implements StreamInterface
 
     public function __toString(): string
     {
-        if ($this->isSeekable()) {
-            $this->rewind();
-        }
+        try {
+            if ($this->isSeekable()) {
+                $this->rewind();
+            }
 
-        return $this->getContents();
+            return $this->getContents();
+        } catch (Throwable) {
+            // __toString must not raise an exception to conform with PHP's string casting operations (PSR-7)
+            return '';
+        }
     }
 
     /**

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -130,6 +130,18 @@ class StreamTest extends StreamIntegrationTest
         self::assertSame('ar', trim((string)$stream));
     }
 
+    public function testConvertsToStringReturnsEmptyForNonReadableStream(): void
+    {
+        $handle = fopen('php://output', 'w');
+        $stream = new Stream($handle); // @phpstan-ignore-line
+
+        self::assertFalse($stream->isReadable());
+        // __toString must not raise an exception to conform with PHP's string casting operations (PSR-7)
+        self::assertSame('', (string)$stream);
+
+        $stream->close();
+    }
+
     public function testGetsContents(): void
     {
         $handle = $this->createTempResource('w+');
@@ -489,9 +501,9 @@ class StreamTest extends StreamIntegrationTest
         $throws(static function () use ($stream): void {
             $stream->getContents();
         });
-        $throws(static function () use ($stream): void {
-            $stream->__toString();
-        });
+
+        // __toString must not raise an exception to conform with PHP's string casting operations (PSR-7)
+        self::assertSame('', (string)$stream);
     }
 
     /**


### PR DESCRIPTION
## Summary

A few small, low-risk improvements to the library.

### Fixed
- **`Stream::__toString()` PSR-7 compliance** — it previously threw a `StreamException` when called on a non-readable or detached stream (via `getContents()`). PSR-7 requires `__toString()` to **not** raise an exception, so it now returns `''` in that case (matching what `BufferedStream::__toString()` already did). The existing test that asserted the old throwing behavior was updated, and a write-only-stream case was added.

### Changed
- Point the codecov badge at the `1.x` branch (was `0.x`).
- Drop dead `export-ignore` entries (`UPGRADING-1.0.md`, `examples`, `docs`) from `.gitattributes`.

### Added
- A **Usage** section in the README with examples for `Stream`, `File`, `TempFile`, `BufferedStream`, and `StreamWrapper`.
- `.editorconfig` (4 spaces, LF, final newline — matches the codebase).

CHANGELOG updated under `[Unreleased]`.

## Notes
Developed without a local PHP toolchain, so CI (PHPCS / PHPStan / PHPUnit) is the verification gate for the code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)